### PR TITLE
Move planet names and descriptions to localization

### DIFF
--- a/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Axod.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Axod.cfg
@@ -18,8 +18,8 @@
         }		
         Properties
         {
-			displayName = Axod^N
-            description = Axod is the bluest object ever observed by kerbalkind, with blue rings, blue clouds and blue skies. What it lacks in size, it makes up for in beautiful views and many unique worlds to explore.
+			displayName = #LOC_PWDD_name_Axod
+            description = #LOC_PWDD_Axod_description
 			
 			radius = 3436477
             geeASL = 1.1

--- a/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Bis.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Bis.cfg
@@ -12,15 +12,16 @@
         }
         Properties
         {
-			displayName = Bis^N
-            description = Bis is Dorau's distant icy companion. Its cracked spotty surface resembles a round biscuit, hence the name.
+			displayName = #LOC_PWDD_name_Bis
+            description = #LOC_PWDD_Bis_description
+
             radius = 180000
             geeASL = 0.189 // Gravity as sea level, 1 being kerbin gravity, 0 being no gravity.
             tidallyLocked = false // Whether or not the body is tidally locked.
             rotates = True // Self-explanatory.
             rotationPeriod = 75800 // Rotation period in seconds.
 			biomeMap = PromisedWorlds/_Systems/Debdeb/PluginData/Bis_Biomes.png
-	    timewarpAltitudeLimits = 0 5000 6000 10000 25000 50000 100000
+			timewarpAltitudeLimits = 0 5000 6000 10000 25000 50000 100000
 			ScienceValues
 			{
 				landedDataValue = 4
@@ -35,31 +36,31 @@
 			{
 				Biome
   				{
-    					name = Lowlands
-					displayName = Lowlands
-    					value = 1
-    					color = 0.282, 0.282, 0.282, 1.0
+					name = Lowlands
+					displayName = #LOC_PWDD_Biome_Lowlands
+					value = 1
+					color = 0.282, 0.282, 0.282, 1.0
   				}
   				Biome
   				{	
-    					name = Midlands
-					displayName = Midlands
-    					value = 0.9
-    					color = 1.0, 1.0, 1.0, 1.0
+					name = Midlands
+					displayName = #LOC_PWDD_Biome_Midlands
+					value = 0.9
+					color = 1.0, 1.0, 1.0, 1.0
   				}
   				Biome
   				{	
-    					name = Highlands
-					displayName = Highlands
-    					value = 1
-    					color = 0.761, 0.761, 0.761, 1.0
+					name = Highlands
+					displayName = #LOC_PWDD_Biome_Highlands
+					value = 1
+    				color = 0.761, 0.761, 0.761, 1.0
   				}
   				Biome
   				{	
-    					name = Equator
-					displayName = Equator
-    					value = 1.25
-    					color = 0.0, 0.0, 0.0, 1.0
+					name = Equator
+					displayName = #LOC_PWDD_Biome_Equator
+    				value = 1.25
+    				color = 0.0, 0.0, 0.0, 1.0
   				}
 			}
         }

--- a/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Charr.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Charr.cfg
@@ -5,20 +5,21 @@
      	name = Charr
        	cacheFile = PromisedWorlds/Cache/Charr.bin // Path to the cache.
 		Tag = PW_Type0
-    	   	Template // Template planet for Kopernicus to use, game breaks a lot without it for some reason.
-    	   	{
-    	   	     	name = Moho
-    	   	     	removeAllPQSMods = True
-   	   	}
-     	  	Properties
-     	   	{
-			displayName = Charr^N
-            		description = Charr is a beaten world of pure iron that basks in Debdeb's intense heat. It's likely the youngest planet in the system and has formed from material inside Debdeb's planetary debris disk. On its discovery, road signage manufacturers rejoiced as they believed they found a gold mine for glow-in-the-dark paint. They were soon dismayed when someone explained that Charr's distinct glow is due to molten iron on its surface, which has previously been proven subpar for use in road signage.
-            		radius = 491000
-            		geeASL = 1.91
-            		tidallyLocked = false
-            		rotates = True
-            		rotationPeriod = 298100
+		Template // Template planet for Kopernicus to use, game breaks a lot without it for some reason.
+		{
+			name = Moho
+			removeAllPQSMods = True
+		}
+		Properties
+		{
+			displayName = #LOC_PWDD_name_Charr
+			description = #LOC_PWDD_Charr_description
+
+			radius = 491000
+			geeASL = 1.91
+			tidallyLocked = false
+			rotates = True
+			rotationPeriod = 298100
 			biomeMap = PromisedWorlds/_Systems/Debdeb/PluginData/Charr_Biomes.png
 			albedo = 0.15
 			emissivity = 1
@@ -34,45 +35,45 @@
 				flyingAltitudeThreshold = 17000
 				spaceAltitudeThreshold = 140000
 			}
-		Biomes
-		{
-			Biome
-  			{
-    				name = MoltenCraters
-				displayName = Molten Craters
-    				value = 5
-    				color = 1.0, 0.753, 0, 1.0
-  			}
-  			Biome
-  			{	
-    				name = HotCraters
-				displayName = Hot Craters
-    				value = 3
-    				color = 1.0, 0.227, 0, 1.0
-  			}
-  			Biome
-  			{	
-    				name = Midlands
-				displayName = Midlands
-    				value = 1.25
-    				color = 0.396, 0.396, 0.396, 1.0
-  			}
-  			Biome
-  			{	
-    				name = Highlands
-				displayName = Highlands
-    				value = 0.9
-    				color = 0.396, 0.396, 0.396, 1.0
-  			}
-  			Biome
-  			{	
-    				name = MetallicMountains
-				displayName = Metallic Mountains
-    				value = 1.75
-    				color = 0.757, 0.757, 0.757, 1.0
-  			}
+			Biomes
+			{
+				Biome
+				{
+					name = MoltenCraters
+					displayName = #LOC_PWDD_Biome_MoltenCraters
+					value = 5
+					color = 1.0, 0.753, 0, 1.0
+				}
+				Biome
+				{
+					name = HotCraters
+					displayName = #LOC_PWDD_Biome_HotCraters
+					value = 3
+					color = 1.0, 0.227, 0, 1.0
+				}
+				Biome
+				{
+					name = Midlands
+					displayName = #LOC_PWDD_Biome_Mid
+					value = 1.25
+					color = 0.396, 0.396, 0.396, 1.0
+				}
+				Biome
+				{
+					name = Highlands
+					displayName = #LOC_PWDD_Biome_High
+					value = 0.9
+					color = 0.396, 0.396, 0.396, 1.0
+				}
+				Biome
+				{
+					name = MetallicMountains
+					displayName = #LOC_PWDD_Biome_MetallicMountains
+					value = 1.75
+					color = 0.757, 0.757, 0.757, 1.0
+				}
+			}
 		}
-        }
         Orbit
         {
             referenceBody = Debdeb // Reference body.

--- a/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Debdeb.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Debdeb.cfg
@@ -10,8 +10,9 @@
         }
         Properties
         {
-            displayName = Debdeb^N
-            description = Debdeb is a G-type main sequence star, slightly dimmer and smaller than Kerbol. It is the closest star to Kerbol, serving as a constant reminder that we are still not the center of the universe. It's a young star surrounded by a proto-planetary disk, in which some planets are forming. It should not be looked at directly, as this causes similar harmful effects to when looking at Kerbol, and has been regarded by some doctors as "A dim-witted thing to do".
+            displayName = #LOC_PWDD_name_Debdeb
+            description = #LOC_PWDD_Debdeb_description
+
             radius = 164808000
             mass = 1.12e+28
             rotates = True

--- a/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Diros.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Diros.cfg
@@ -12,15 +12,16 @@
         }
         Properties
         {
-			displayName = Diros^N
-            description = Diros is the larger body of its binary pair. It has some impressive terrain with mountains and craters across its surface. From here, one can observe the entire Glumo system at once.
+			displayName = #LOC_PWDD_name_Diros
+            description = #LOC_PWDD_Diros_description
+
             radius = 125000
             geeASL = 0.1 // Gravity as sea level, 1 being kerbin gravity, 0 being no gravity.
             tidallyLocked = true // Whether or not the body is tidally locked.
             rotates = True // Self-explanatory.
             rotationPeriod = 15800 // Rotation period in seconds.
 			biomeMap = PromisedWorlds/_Systems/Debdeb/PluginData/Diros_Biomes.png
-	    timewarpAltitudeLimits = 0 5000 6000 10000 25000 50000 100000
+			timewarpAltitudeLimits = 0 5000 6000 10000 25000 50000 100000
 			ScienceValues
 			{
 				landedDataValue = 4
@@ -35,38 +36,38 @@
 			{
 				Biome
   				{
-    					name = Lowlands
-					displayName = Lowlands
-    					value = 7
-    					color = 0.412, 0.314, 0.816, 1.0
+					name = Lowlands
+					displayName = #LOC_PWDD_Biome_Low
+					value = 7
+					color = 0.412, 0.314, 0.816, 1.0
   				}
   				Biome
   				{	
-    					name = Midlands
-					displayName = Midlands
-    					value = 3
-    					color = 0.478, 0.459, 0.827, 1.0
+					name = Midlands
+					displayName = #LOC_PWDD_Biome_Mid
+					value = 3
+					color = 0.478, 0.459, 0.827, 1.0
   				}
   				Biome
   				{	
-    					name = Highlands
-					displayName = Highlands
-    					value = 1.25
-    					color = 0.537, 0.616, 0.816, 1.0
+					name = Highlands
+					displayName = #LOC_PWDD_Biome_High
+					value = 1.25
+					color = 0.537, 0.616, 0.816, 1.0
   				}
   				Biome
   				{	
-    					name = Mountains
-					displayName = Mountains
-    					value = 1.25
-    					color = 0.561, 0.690, 0.812, 1.0
+					name = Mountains
+					displayName = #LOC_PWDD_Biome_Mountains
+					value = 1.25
+					color = 0.561, 0.690, 0.812, 1.0
   				}
   				Biome
   				{	
-    					name = Poles
-					displayName = Poles
-    					value = 0.9
-    					color = 0.0, 0.0, 0.0, 1.0
+					name = Poles
+					displayName = #LOC_PWDD_Biome_Poles
+					value = 0.9
+					color = 0.0, 0.0, 0.0, 1.0
   				}
 			}
         }

--- a/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Donk.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Donk.cfg
@@ -12,8 +12,9 @@
         }
         Properties
         {
-			displayName = Donk^N
-            description = It's believed that Donk was formed from a collision between Gurdamma and another nearby planet, hence the ring that it is forming in. It's surface is young, with patches of cooled lava across it's surface. When asked what to name this newly-discovered moon, Nate Kerman recalled a particular high-velocity encounter his head had with the top of the observatory door that evening. And so Donk was the new big space discovery that everybody was talking about. 
+			displayName = #LOC_PWDD_name_Donk
+            description = #LOC_PWDD_Donk_description
+
             radius = 192000
             geeASL = 0.166 // Gravity as sea level, 1 being kerbin gravity, 0 being no gravity.
             tidallyLocked = true // Whether or not the body is tidally locked.
@@ -37,70 +38,70 @@
 			Biome
   			{
     				name = Lava Lakes
-				displayName = Lava Lakes
+				displayName = #LOC_PWDD_Biome_LavaLakes
     				value = 2
     				color = 1.0, 0.290, 0.0, 1.0
   			}
 			Biome
   			{
     				name = Basalt Basins
-				displayName = Basalt Basins
+				displayName = #LOC_PWDD_Biome_BasaltBasins
     				value = 1.5
     				color = 0.155, 0.155, 0.155, 1.0
   			}
 			Biome
   			{
     				name = Mares
-				displayName = Mares
+				displayName = #LOC_PWDD_Biome_Mares
     				value = 1.1
     				color = 0.404, 0.404, 0.404, 1.0
   			}
 			Biome
   			{
     				name = Midlands
-				displayName = Midlands
+				displayName = #LOC_PWDD_Biome_Mid
     				value = 0.9
     				color = 0.514, 0.514, 0.514, 1.0
   			}
 			Biome
   			{
     				name = Highlands
-				displayName = Highlands
+				displayName = #LOC_PWDD_Biome_High
     				value = 1
     				color = 0.671, 0.671, 0.671, 1.0
   			}
 			Biome
   			{
     				name = Mountains
-				displayName = Mountains
+				displayName = #LOC_PWDD_Biome_Mountains
     				value = 1
     				color = 1.0, 1.0, 1.0, 1.0
   			}
 			Biome
   			{
     				name = Craters
-				displayName = Craters
+				displayName = #LOC_PWDD_Biome_Craters
     				value = 1
     				color = 0.0, 0.592, 0.573, 1.0
   			}
 			Biome
   			{
     				name = Polar Lowlands
-				displayName = Polar Lowlands
+				displayName = #LOC_PWDD_Biome_PolarLow
     				value = 1
     				color = 0.129, 0.380, 0.0, 1.0
   			}
 			Biome
   			{
     				name = Polar Midlands
-				displayName = Polar Midlands
+				displayName = #LOC_PWDD_Biome_PolarMid
     				value = 1
     				color = 0.0, 0.784, 0.0, 1.0
   			}
 			Biome
   			{
     				name = Polar Highlands
-				displayName = Polar Highlands
+				displayName = #LOC_PWDD_Biome_PolarHigh
     				value = 1
     				color = 0.0, 1.0, 0.02, 1.0
   			}

--- a/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Dorau.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Dorau.cfg
@@ -12,8 +12,9 @@
         }
         Properties
         {
-			displayName = Dorau^N
-            description = Dorau is a cold snowball lurking in the farthest reaches of the Debdeb system. It was called a planet from day one and anybody who thought otherwise was shown the door. Its poofy atmosphere makes it look fuzzy when observed, like a space pompom. Its most unique features are the liquid nitrogen lakes seen dotted across its surface. Kerbal engineers claim that their standard spacesuits are "probably" able to handle a swim there.
+			displayName = #LOC_PWDD_name_Dorau
+            description = #LOC_PWDD_Dorau_description
+
             radius = 375000
             geeASL = 0.32 // Gravity as sea level, 1 being kerbin gravity, 0 being no gravity.
             tidallyLocked = false // Whether or not the body is tidally locked.
@@ -36,35 +37,35 @@
   				Biome
   				{	
     					name = Shores
-					displayName = Shores
+					displayName = #LOC_PWDD_Biome_Shores
     					value = 1.25
     					color = 1.0, 1.0, 1.0, 1.0
   				}
 				Biome
   				{
     					name = Lowlands
-					displayName = Lowlands
+					displayName = #LOC_PWDD_Biome_Low
     					value = 1
     					color = 0.529, 0.529, 0.529, 1.0
   				}
   				Biome
   				{	
     					name = Midlands
-					displayName = Midlands
+					displayName = #LOC_PWDD_Biome_Mid
     					value = 0.9
     					color = 0.714, 0.714, 0.714, 1.0
   				}
   				Biome
   				{	
     					name = Highlands
-					displayName = Highlands
+					displayName = #LOC_PWDD_Biome_High
     					value = 1.1
     					color = 0.0, 0.0, 0.0, 1.0
   				}
   				Biome
   				{	
     					name = Nitrogen Seas
-					displayName = Nitrogen Seas
+					displayName = #LOC_PWDD_Biome_NitrogenSeas
     					value = 2
     					color = 1.0, 0.0, 1.0, 1.0
   				}

--- a/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Glumo.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Glumo.cfg
@@ -17,8 +17,8 @@
         }		
         Properties
         {
-			displayName = Glumo^N
-            description = Glumo is the largest planet of the Debdeb system, with a complex ring system and clouds of many colors. Its monstrous size puts Jool to shame. The view of the vast ring system from the moons must be spectacular. It has starred in many prog rock covers since its discovery.
+			displayName = #LOC_PWDD_name_Glumo
+            description = #LOC_PWDD_Glumo_description
 			
 			albedo = 0.5
 			radius = 7050000

--- a/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Gup.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Gup.cfg
@@ -12,8 +12,9 @@
         }
         Properties
         {
-			displayName = Gup^N
-            description = Gup is a little disk of rock with a crazy orbit. It's existence further proves the Gurdamma collision theory as it is likely a piece of ejected material. It was likely flung like a frisbee out into space, hence it's fast rotation and flat shape. It's resemblence to a flying saucer has led to many embarassing reports and several astronomers being driven to insanity. Please wear a jetpack when walking near the equator. The Kerbal Astronomical Society is yet to determine the feasability of using it for games of space-frisbee.
+			displayName = #LOC_PWDD_name_Gup
+            description = #LOC_PWDD_Gup_description
+
             radius = 8000
             geeASL = 0.0046 // Gravity as sea level, 1 being kerbin gravity, 0 being no gravity.
             tidallyLocked = false // Whether or not the body is tidally locked.
@@ -49,31 +50,31 @@
 		{
 			Biome
   			{
-    				name = Equatorial Ridge
-				displayName = Equatorial Ridge
-    				value = 1.75
-    				color = 1.0, 1.0, 1.0, 1.0
+				name = Equatorial Ridge
+				displayName = #LOC_PWDD_Biome_EquatorialRidge
+				value = 1.75
+				color = 1.0, 1.0, 1.0, 1.0
   			}
 			Biome
   			{
-    				name = Slopes
-				displayName = Slopes
-    				value = 1.5
-    				color = 1.0, 0.624, 1.0, 1.0
+				name = Slopes
+				displayName = #LOC_PWDD_Biome_Slopes
+				value = 1.5
+				color = 1.0, 0.624, 1.0, 1.0
   			}
 			Biome
   			{
-    				name = Midlands
-				displayName = Midlands
-    				value = 1.0
-    				color = 0.855, 0.345, 1.0, 1.0
+				name = Midlands
+				displayName = #LOC_PWDD_Biome_Mid
+				value = 1.0
+				color = 0.855, 0.345, 1.0, 1.0
   			}
 			Biome
   			{
-    				name = Poles
-				displayName = Poles
-    				value = 1.25
-    				color = 0.576, 0.0, 1.0, 1.0
+				name = Poles
+				displayName = #LOC_PWDD_Biome_Poles
+				value = 1.25
+				color = 0.576, 0.0, 1.0, 1.0
   			}
 		}
         }

--- a/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Gurdamma.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Gurdamma.cfg
@@ -12,8 +12,8 @@
         }
         Properties
         {
-			displayName = Gurdamma^N
-            description = Kerbalkind's first stop on the way to the Debdeb system. Gurdamma offers a glimpse at what Kerbin could have looked like during the Kadeon eon, 4 billion years ago. It has an active, shifting surface, which is pockmarked all over with many craters of all shapes and sizes, hinting at a major cosmic event in the recent past. There are also vast water oceans just like Kerbin, but it's atmosphere is toxic with very little oxygen present. It dons a beautiful ring system where it's largest moon, Donk, is currently forming. Knowing what we do about our own planet, one can only wonder what sort of future this planet has in store.
+			displayName = #LOC_PWDD_name_Gurdamma
+            description = #LOC_PWDD_Gurdamma_description
             radius = 580000
             geeASL = 0.94 // Gravity as sea level, 1 being kerbin gravity, 0 being no gravity.
             tidallyLocked = false // Whether or not the body is tidally locked.
@@ -37,119 +37,119 @@
 			Biome
   			{
     				name = Deep Oceans
-				displayName = Deep Oceans
+				displayName = #LOC_PWDD_Biome_DeepOceans
     				value = 1.5
     				color = 0.537, 0.616, 0.816, 1.0
   			}
   			Biome
   			{	
     				name = Oceans
-				displayName = Oceans
+				displayName = #LOC_PWDD_Biome_Oceans
     				value = 1.2
     				color = 0.561, 0.690, 0.812, 1.0
   			}
   			Biome
   			{	
     				name = Crater Lakes
-				displayName = Crater Lakes
+				displayName = #LOC_PWDD_Biome_CraterLakes
     				value = 1.3
     				color = 0.561, 1.0, 1.0, 1.0
   			}
   			Biome
   			{	
     				name = Lowlands
-				displayName = Lowlands
+				displayName = #LOC_PWDD_Biome_Low
     				value = 1
     				color = 0.396, 0.396, 0.396, 1.0
   			}
   			Biome
   			{	
     				name = Highlands
-				displayName = Highlands
+				displayName = #LOC_PWDD_Biome_High
     				value = 1.25
     				color = 0.800, 0.482, 0.745, 1.0
   			}
   			Biome
   			{	
     				name = Mountains
-				displayName = Mountains
+				displayName = #LOC_PWDD_Biome_Mountains
     				value = 1.6
     				color = 0.753, 0.396, 0.761, 1.0
   			}
   			Biome
   			{	
     				name = Volcanoes
-				displayName = Volcanoes
+				displayName = #LOC_PWDD_Biome_Volcanoes
     				value = 2.25
     				color = 0.996, 0.0, 0.0, 1.0
   			}
   			Biome
   			{	
     				name = Mount Bogue
-				displayName = Mount Bogue
+				displayName = #LOC_PWDD_Biome_MountBogue
     				value = 2.5
     				color = 1.0, 0.0, 0.5, 1.0
   			}
   			Biome
   			{	
     				name = Ashen Lowlands
-				displayName = Ashen Lowlands
+				displayName = #LOC_PWDD_Biome_AshenLow
     				value = 1.1
     				color = 0.498, 0.525, 0.831, 1.0
   			}
   			Biome
   			{	
     				name = Ashen Highlands
-				displayName = Ashen Highlands
+				displayName = #LOC_PWDD_Biome_AshenHigh
     				value = 1.35
     				color = 0.486, 0.404, 0.816, 1.0
   			}
   			Biome
   			{	
     				name = Ashen Mountains
-				displayName = Ashen Mountains
+				displayName = #LOC_PWDD_Biome_AshenMountains
     				value = 1.75
     				color = 0.412, 0.314, 0.816, 1.0
   			}
   			Biome
   			{	
     				name = Shankast River
-				displayName = Shankast River
+				displayName = #LOC_PWDD_Biome_ShankastRiver
     				value = 1.32
     				color = 0.337, 0.125, 0.808, 1.0
   			}
   			Biome
   			{	
     				name = Teal River
-				displayName = Teal River
+				displayName = #LOC_PWDD_Biome_TealRiver
     				value = 1.32
     				color = 0.337, 0.125, 0.808, 1.0
   			}
   			Biome
   			{	
     				name = Mylon River
-				displayName = Mylon River
+				displayName = #LOC_PWDD_Biome_MylonRiver
     				value = 1.32
     				color = 0.592, 0.133, 0.827, 1.0
   			}
   			Biome
   			{	
     				name = Faultlines
-				displayName = Faultlines
+				displayName = #LOC_PWDD_Biome_Faultlines
     				value = 1.85
     				color = 0.851, 1.0, 0.839, 1.0
   			}
   			Biome
   			{	
     				name = Ashen Faultlines
-				displayName = Ashen Faultlines
+				displayName = #LOC_PWDD_Biome_AshenFaultlines
     				value = 1.9
     				color = 0.506, 1.0, 0.859, 1.0
   			}
   			Biome
   			{	
     				name = Flooded Faultlines
-				displayName = Flooded Faultlines
+				displayName = #LOC_PWDD_Biome_FloodedFaultlines
     				value = 2
     				color = 0.98, 0.694, 1.0, 1.0
   			}

--- a/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Jut.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Jut.cfg
@@ -12,7 +12,9 @@
         }
         Properties
         {
-            description = Jut is the smaller of its binary pair. It is known for its "swiss cheese" appearance and chaotic rotation. KSC does not recommend attempts to eat it.
+            displayName = #LOC_PWDD_name_Jut
+            description = #LOC_PWDD_Jut_description
+
             radius = 35000
             geeASL = 0.018 // Gravity as sea level, 1 being kerbin gravity, 0 being no gravity.
             tidallyLocked = false // Whether or not the body is tidally locked.
@@ -35,28 +37,28 @@
 				Biome
   				{
     					name = Lowlands
-					displayName = Lowlands
+					displayName = #LOC_PWDD_Biome_Low
     					value = 1
     					color = 0.282, 0.282, 0.282, 1.0
   				}
   				Biome
   				{	
     					name = Midlands
-					displayName = Midlands
+					displayName = #LOC_PWDD_Biome_Mid
     					value = 0.9
     					color = 1.0, 1.0, 1.0, 1.0
   				}
   				Biome
   				{	
     					name = Highlands
-					displayName = Highlands
+					displayName = #LOC_PWDD_Biome_High
     					value = 1
     					color = 0.761, 0.761, 0.761, 1.0
   				}
   				Biome
   				{	
     					name = Equator
-					displayName = Equator
+					displayName = #LOC_PWDD_Biome_Equator
     					value = 1.25
     					color = 0.0, 0.0, 0.0, 1.0
   				}

--- a/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Kleid.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Kleid.cfg
@@ -12,8 +12,9 @@
         }
         Properties
         {
-			displayName = Kleid^N
-            description = 
+			displayName = #LOC_PWDD_name_Kleid
+            description = #LOC_PWDD_Kleid_description
+
             radius = 165000
             geeASL = 0.13 // Gravity as sea level, 1 being kerbin gravity, 0 being no gravity.
             tidallyLocked = true // Whether or not the body is tidally locked.
@@ -36,42 +37,42 @@
 				Biome
   				{
     					name = Lowlands
-					displayName = Lowlands
+					displayName = #LOC_PWDD_Biome_Low
     					value = 7
     					color = 0.412, 0.314, 0.816, 1.0
   				}
   				Biome
   				{	
     					name = Midlands
-					displayName = Midlands
+					displayName = #LOC_PWDD_Biome_Mid
     					value = 3
     					color = 0.478, 0.459, 0.827, 1.0
   				}
   				Biome
   				{	
     					name = Highlands
-					displayName = Highlands
+					displayName = #LOC_PWDD_Biome_High
     					value = 1.25
     					color = 0.537, 0.616, 0.816, 1.0
   				}
   				Biome
   				{	
     					name = Mountains
-					displayName = Mountains
+					displayName = #LOC_PWDD_Biome_Mountains
     					value = 1.25
     					color = 0.561, 0.690, 0.812, 1.0
   				}
   				Biome
   				{	
     					name = Poles
-					displayName = Poles
+					displayName = #LOC_PWDD_Biome_Poles
     					value = 0.9
     					color = 0.0, 0.0, 0.0, 1.0
   				}
   				Biome
   				{	
     					name = Canyons
-					displayName = Canyons
+					displayName = #LOC_PWDD_Biome_Canyons
     					value = 1.75
     					color = 1.0, 1.0, 1.0, 1.0
   				}

--- a/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Lapat.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Lapat.cfg
@@ -12,8 +12,8 @@
         }
         Properties
         {
-			displayName = Lapat^N
-            description = Don't be turned away by its angry-red oceans. Lapat is a heavenly respite from the chaos of the inner Debdeb system. Despite being mostly icy, Lapat has some habitable features around the equator. How it got its oxygen-rich atmosphere at such a young age is a mystery, making it one of the most anomalous bodies in the Debdeb system.
+			displayName = #LOC_PWDD_name_Lapat
+            description = #LOC_PWDD_Lapat_description
             radius = 370000
             geeASL = 0.46 // Gravity as sea level, 1 being kerbin gravity, 0 being no gravity.
             tidallyLocked = false // Whether or not the body is tidally locked.
@@ -38,77 +38,77 @@
 			Biome
   			{
     				name = Deep Oceans
-				displayName = Deep Oceans
+				displayName = #LOC_PWDD_Biome_DeepOceans
     				value = 1.5
     				color = 0.498, 0.0, 0.0, 1.0
   			}
   			Biome
   			{	
     				name = Oceans
-				displayName = Oceans
+				displayName = #LOC_PWDD_Biome_Oceans
     				value = 1.2
     				color = 1.0, 0.035, 0.0, 1.0
   			}
   			Biome
   			{	
     				name = Shores
-				displayName = Shores
+				displayName = #LOC_PWDD_Biome_Shores
     				value = 1.1
     				color = 0.831, 0.576, 0.718, 1.0
   			}
   			Biome
   			{	
     				name = Lowlands
-				displayName = Lowlands
+				displayName = #LOC_PWDD_Biome_Low
     				value = 1
     				color = 0.753, 0.396, 0.761, 1.0
   			}
   			Biome
   			{	
     				name = Midlands
-				displayName = Midlands
+				displayName = #LOC_PWDD_Biome_Mid
     				value = 1.2
     				color = 0.851, 0.671, 0.686, 1.0
   			}
   			Biome
   			{	
     				name = Highlands
-				displayName = Highlands
+				displayName = #LOC_PWDD_Biome_High
     				value = 1.25
     				color = 0.776, 0.831, 0.643, 1.0
   			}
   			Biome
   			{	
     				name = Mountains
-				displayName = Mountains
+				displayName = #LOC_PWDD_Biome_Mountains
     				value = 1.4
     				color = 1.0, 1.0, 1.0, 1.0
   			}
   			Biome
   			{	
     				name = Icy Cliffs
-				displayName = Icy Cliffs
+				displayName = #LOC_PWDD_Biome_IcyCliffs
     				value = 2
     				color = 0.647, 0.945, 0.675, 1.0
   			}
   			Biome
   			{	
     				name = Icy Lowlands
-				displayName = Icy Lowlands
+				displayName = #LOC_PWDD_Biome_IcyLow
     				value = 1.1
     				color = 0.537, 0.882, 0.682, 1.0
   			}
   			Biome
   			{	
     				name = Icy Highlands
-				displayName = Icy Highlands
+				displayName = #LOC_PWDD_Biome_IcyHigh
     				value = 1.2
     				color = 0.561, 0.694, 0.812, 1.0
   			}
   			Biome
   			{	
     				name = Icy Hills
-				displayName = Icy Hills
+				displayName = #LOC_PWDD_Biome_IcyHills
     				value = 1.65
     				color = 0.537, 0.616, 0.820, 1.0
   			}

--- a/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Merbel.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Merbel.cfg
@@ -12,8 +12,8 @@
         }
         Properties
         {
-			displayName = Merbel^N
-            description = Don't be fooled by this place. Merbel may have blue skies, stunning views and an ocean from paradise, but the oceans are full of toxic copper sulphate and there isn't enough oxygen in the air to breathe. It's still very pretty though and the place still has a lot to offer with some refining. Merbel's orbit and size suggests it was once a planet itself. As Glumo moved outwards through the Debdeb system, Merbel was snatched and forced into a wacky orbit. This event may have helped form Glumo's spectacular rings.
+			displayName = #LOC_PWDD_name_Merbel
+            description = #LOC_PWDD_Merbel_description
             radius = 406000
             geeASL = 0.46 // Gravity as sea level, 1 being kerbin gravity, 0 being no gravity.
             tidallyLocked = false // Whether or not the body is tidally locked.
@@ -38,112 +38,112 @@
   				Biome
   				{	
     					name = DeepSeas
-					displayName = Deep Seas
+					displayName = #LOC_PWDD_Biome_DeepSeas
     					value = 1.75
     					color = 0.408, 0.314, 0.816, 1.0
   				}
 				Biome
   				{
     					name = Seas
-					displayName = Seas
+					displayName = #LOC_PWDD_Biome_Seas
     					value = 1.25
     					color = 0.478, 0.459, 0.827, 1.0
   				}
   				Biome
   				{	
     					name = ShallowSeas
-					displayName = Shallow Seas
+					displayName = #LOC_PWDD_Biome_ShallowSeas
     					value = 1.25
     					color = 0.537, 0.616, 0.820, 1.0
   				}
   				Biome
   				{	
     					name = Coasts
-					displayName = Coasts
+					displayName = #LOC_PWDD_Biome_Coasts
     					value = 1.1
     					color = 0.702, 0.212, 0.529, 1.0
   				}
   				Biome
   				{	
     					name = Lowlands
-					displayName = Lowlands
+					displayName = #LOC_PWDD_Biome_Low
     					value = 0.9
     					color = 0.769, 0.271, 0.596, 1.0
   				}
   				Biome
   				{	
     					name = Midlands
-					displayName = Midlands
+					displayName = #LOC_PWDD_Biome_Mid
     					value = 1
     					color = 0.812, 0.302, 0.561, 1.0
   				}
   				Biome
   				{	
     					name = Highlands
-					displayName = Highlands
+					displayName = #LOC_PWDD_Biome_High
     					value = 1.1
     					color = 0.855, 0.376, 0.533, 1.0
   				}
   				Biome
   				{	
     					name = Mountains
-					displayName = Mountains
+					displayName = #LOC_PWDD_Biome_Mountains
     					value = 2
     					color = 0.906, 0.588, 0.459, 1.0
   				}
   				Biome
   				{	
     					name = PolarDeepSeas
-					displayName = Polar Deep Seas
+					displayName = #LOC_PWDD_Biome_PolarDeepSeas
     					value = 2
     					color = 0.816, 0.627, 1.0, 1.0
   				}
   				Biome
   				{	
     					name = PolarSeas
-					displayName = Polar Seas
+					displayName = #LOC_PWDD_Biome_PolarSeas
     					value = 1.35
     					color = 0.957, 0.918, 1.0, 1.0
   				}
   				Biome
   				{	
     					name = PolarShallowSeas
-					displayName = Polar Shallow Seas
+					displayName = #LOC_PWDD_Biome_PolarShallowSeas
     					value = 1.35
     					color = 1.0, 1.0, 1.0, 1.0
   				}
   				Biome
   				{	
     					name = PolarCoasts
-					displayName = Polar Coasts
+					displayName = #LOC_PWDD_Biome_PolarCoasts
     					value = 1.16
     					color = 0.145, 0.345, 0.027, 1.0
   				}
   				Biome
   				{	
     					name = PolarLowlands
-					displayName = Polar Lowlands
+					displayName = #LOC_PWDD_Biome_PolarLow
     					value = 1
     					color = 0.212, 0.286, 0.039, 1.0
   				}
   				Biome
   				{	
     					name = PolarMidlands
-					displayName = Polar Midlands
+					displayName = #LOC_PWDD_Biome_PolarMid
     					value = 1
     					color = 0.255, 0.255, 0.040, 1.0
   				}
   				Biome
   				{	
     					name = PolarHighlands
-					displayName = Polar Highlands
+					displayName = #LOC_PWDD_Biome_PolarHigh
     					value = 1.5
     					color = 0.298, 0.180, 0.024, 1.0
   				}
   				Biome
   				{	
     					name = PolarMountains
-					displayName = Polar Mountains
+					displayName = #LOC_PWDD_Biome_PolarMountains
     					value = 2.6
     					color = 0.349, 0.031, 0.098, 1.0
   				}

--- a/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Mesma.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Mesma.cfg
@@ -13,12 +13,11 @@
 		}
 		Properties
 		{
-			displayName = Mesma^N
-			description = Mesma is Axod's most unusual companion. It's surface is dominated by icy plains with some rocky hills poking through. Some say it resembles a burnt marshmallow... a space marshmallow... yum.
+			displayName = #LOC_PWDD_name_Mesma
+			description = #LOC_PWDD_Mesma_description
 
 			radius = 195000
 			geeASL = 0.13
-			displayName = Mesma^N
 			rotates = true
 			rotationPeriod = -7400.75216749825
 			biomeMap = PromisedWorlds/_Systems/Debdeb/PluginData/Mesma_Biomes.png
@@ -42,35 +41,35 @@
 				Biome
   				{
     					name = Cracks
-					displayName = Cracks
+					displayName = #LOC_PWDD_Biome_Cracks
     					value = 7
     					color = 0.204, 0.235, 0.278, 1.0
   				}
   				Biome
   				{	
     					name = Ice Sheets
-					displayName = Ice Sheets
+					displayName = #LOC_PWDD_Biome_IceSheets
     					value = 3
     					color = 1.0, 1.0, 1.0, 1.0
   				}
   				Biome
   				{	
     					name = Rocky Flats
-					displayName = Rocky Flats
+					displayName = #LOC_PWDD_Biome_RockyFlats
     					value = 1.25
     					color = 0.561, 0.769, 0.792, 1.0
   				}
   				Biome
   				{	
     					name = Rocky Slopes
-					displayName = Rocky Slopes
+					displayName = #LOC_PWDD_Biome_RockySlopes
     					value = 1.25
     					color = 0.561, 0.690, 0.812, 1.0
   				}
   				Biome
   				{	
     					name = Rocky Mountains
-					displayName = Rocky Mountains
+					displayName = #LOC_PWDD_Biome_RockyMountains
     					value = 0.9
     					color = 0.537, 0.616, 0.816, 1.0
   				}

--- a/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Noj.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Noj.cfg
@@ -12,8 +12,8 @@
         }
         Properties
         {
-			displayName = Noj^N
-            description = Noj is in an awkward place. Due to its puny size and precarious orbit, it is almost inaccessible. Many compare its appearance to a frisbee, a scone, or a raviolo. This is from the accumulation of material from Glumo's rings. This process has also traced out a gap through the rings.
+			displayName = #LOC_PWDD_name_Noj
+            description = #LOC_PWDD_Noj_description
             radius = 3500
             geeASL = 0.003 // Gravity as sea level, 1 being kerbin gravity, 0 being no gravity.
             tidallyLocked = true // Whether or not the body is tidally locked.
@@ -36,28 +36,28 @@
 			//	Biome
   			//	{
     			//		name = Lowlands
-			//		displayName = Lowlands
+			//		displayName = #LOC_PWDD_Biome_Low
     			//		value = 1
     			//		color = 0.282, 0.282, 0.282, 1.0
   			//	}
   			//	Biome
   			//	{	
     			//		name = Midlands
-			//		displayName = Midlands
+			//		displayName = #LOC_PWDD_Biome_Mid
     			//		value = 0.9
     			//		color = 1.0, 1.0, 1.0, 1.0
   			//	}
   			//	Biome
   			//	{	
     			//		name = Highlands
-			//		displayName = Highlands
+			//		displayName = #LOC_PWDD_Biome_High
     			//		value = 1
     			//		color = 0.761, 0.761, 0.761, 1.0
   			//	}
   			//	Biome
   			//	{	
     			//		name = Equator
-			//		displayName = Equator
+			//		displayName = #LOC_PWDD_Biome_Equator
     			//		value = 1.25
     			//		color = 0.0, 0.0, 0.0, 1.0
   			//	}

--- a/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Omasa.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Omasa.cfg
@@ -13,11 +13,11 @@
 		}
 		Properties
 		{
-			description = Omasa matches Mesma's orbit on the opposite side. An unusual arrangement which earned the two moons names after twin knights from Kerbal mythology. This can be deceiving as up close they are nothing alike at all.
+			displayName = #LOC_PWDD_name_Omasa
+			description = #LOC_PWDD_Omasa_description
 
 			radius = 100000
 			geeASL = 0.08
-			displayName = Omasa^N
 			rotates = true
 			rotationPeriod = -7400.75216749825
 			biomeMap = PromisedWorlds/_Systems/Debdeb/PluginData/Omasa_Biomes.png
@@ -41,28 +41,28 @@
 				Biome
   				{
     					name = Lowlands
-					displayName = Lowlands
+					displayName = #LOC_PWDD_Biome_Low
     					value = 7
     					color = 0.412, 0.314, 0.816, 1.0
   				}
   				Biome
   				{	
     					name = Midlands
-					displayName = Midlands
+					displayName = #LOC_PWDD_Biome_Mid
     					value = 3
     					color = 0.478, 0.459, 0.827, 1.0
   				}
   				Biome
   				{	
     					name = Highlands
-					displayName = Highlands
+					displayName = #LOC_PWDD_Biome_High
     					value = 1.25
     					color = 0.537, 0.616, 0.816, 1.0
   				}
   				Biome
   				{	
     					name = Peaks
-					displayName = Peaks
+					displayName = #LOC_PWDD_Biome_Peaks
     					value = 1.25
     					color = 0.561, 0.690, 0.812, 1.0
   				}

--- a/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Ovin.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Ovin.cfg
@@ -12,8 +12,8 @@
         }
         Properties
         {
-			displayName = Ovin^N
-            description = With a choked atmosphere that eats spacecraft for breakfast, a shattered surface with few places to land and a fierce gravitational pull that threatens to crush the bones of any kerbal who dares to walk on it's surface, Ovin is a horrifying planet and will be a colossal challenge for kerbalkind to conquer. It's monstrous size and density makes us believe that it may be the core of a gas giant that lost it's atmosphere in some cosmic event. It's discovery re-defined how we think about terrestrial planets and undoubtedly gave some kids (and scientists) nightmares for many months.
+			displayName = #LOC_PWDD_name_Ovin
+            description = #LOC_PWDD_Ovin_description
             radius = 1154000
             geeASL = 4.04 // Gravity at sea level, 1 being kerbin gravity, 0 being no gravity.
             tidallyLocked = false // Whether or not the body is tidally locked.
@@ -37,91 +37,91 @@
 			Biome
   			{
     				name = Lowlands
-					displayName = Lowlands
+					displayName = #LOC_PWDD_Biome_Low
     				value = 1
     				color = 0.098, 0.098, 0.098, 1.0
   			}
   			Biome
-  			{	
+  			{
     				name = Midlands
-				displayName = Midlands
+				displayName = #LOC_PWDD_Biome_Mid
     				value = 0.9
     				color = 0.376, 0.337, 0.298, 1.0
   			}
   			Biome
-  			{	
+  			{
     				name = Highlands
-				displayName = Highlands
+				displayName = #LOC_PWDD_Biome_High
     				value = 1.5
     				color = 0.565, 0.533, 0.482, 1.0
   			}
   			Biome
-  			{	
+  			{
     				name = Mountains
-				displayName = Mountains
+				displayName = #LOC_PWDD_Biome_Mountains
     				value = 4
     				color = 1.0, 1.0, 1.0, 1.0
   			}
   			Biome
-  			{	
+  			{
     				name = Nedzerfjord
-				displayName = Nedzerfjord
+				displayName = #LOC_PWDD_Biome_Nedzerfjord
     				value = 7
     				color = 0.0, 0.835, 1.0, 1.0
   			}
   			Biome
-  			{	
+  			{
     				name = Valley of Despair
-				displayName = Valley of Despair
+				displayName = #LOC_PWDD_Biome_ValleyOfDespair
     				value = 5
     				color = 0.04, 1.0, 0.176, 1.0
   			}
   			Biome
-  			{	
+  			{
     				name = Gulf of Hairy
-				displayName = Gulf of Hairy
+				displayName = #LOC_PWDD_Biome_GulfOfHairy
     				value = 7
     				color = 0.0, 0.357, 0.996, 1.0
   			}
   			Biome
-  			{	
+  			{
     				name = Dusty Crater
-				displayName = Dusty Crater
+				displayName = #LOC_PWDD_Biome_DustyCrater
     				value = 3
     				color = 0.435, 0.0, 1.0, 1.0
   			}
   			Biome
-  			{	
+  			{
     				name = Heffty Cliffs
-				displayName = Heffty Cliffs
+				displayName = #LOC_PWDD_Biome_HefftyCliffs
     				value = 7
     				color = 0.157, 1.0, 0.525, 1.0
   			}
   			Biome
-  			{	
+  			{
     				name = Great Northern Rift
-				displayName = Great Northern Rift
+				displayName = #LOC_PWDD_Biome_GreatNorthernRift
     				value = 4
     				color = 1.0, 0.439, 0.0, 1.0
   			}
   			Biome
-  			{	
+  			{
     				name = Great Southern Rift
-				displayName = Great Southern Rift
+				displayName = #LOC_PWDD_Biome_GreatSouthernRift
     				value = 4
     				color = 1.0, 0.678, 0.0, 1.0
   			}
   			Biome
-  			{	
+  			{
     				name = Lesser Northern Rift
-				displayName = Lesser Northern Rift
+				displayName = #LOC_PWDD_Biome_LesserNorthernRift
     				value = 5
     				color = 1.0, 1.0, 0.0, 1.0
   			}
   			Biome
-  			{	
+  			{
     				name = Vinita Fissure
-				displayName = Vinita Fissure
+				displayName = #LOC_PWDD_Biome_VinitaFissure
     				value = 6
     				color = 1.0, 0.0, 0.0, 1.0
   			}

--- a/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Rosh.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Rosh.cfg
@@ -12,8 +12,9 @@
         }
         Properties
         {
-			displayName = Rosh^N
-            description = Rosh is Axod's largest moon. Its grimy surface is as black as coal, however it is unlikely that there is any coal there. Some compare its many planitiae to the inside of an onion.
+			displayName = #LOC_PWDD_name_Rosh
+            description = #LOC_PWDD_Rosh_description
+
             radius = 250000
             geeASL = 0.2 // Gravity as sea level, 1 being kerbin gravity, 0 being no gravity.
             tidallyLocked = true // Whether or not the body is tidally locked.
@@ -40,42 +41,42 @@
 				Biome
   				{
     					name = Lowlands
-					displayName = Lowlands
+					displayName = #LOC_PWDD_Biome_Low
     					value = 7
     					color = 0.698, 0.267, 0.780, 1.0
   				}
   				Biome
-  				{	
+  				{
     					name = Midlands
-					displayName = Midlands
+					displayName = #LOC_PWDD_Biome_Mid
     					value = 3
     					color = 0.753, 0.396, 0.773, 1.0
   				}
   				Biome
-  				{	
+  				{
     					name = Highlands
-					displayName = Highlands
+					displayName = #LOC_PWDD_Biome_High
     					value = 1.25
     					color = 0.835, 0.517, 0.718, 1.0
   				}
   				Biome
-  				{	
+  				{
     					name = Peaks
-					displayName = Peaks
+					displayName = #LOC_PWDD_Biome_Peaks
     					value = 1.25
     					color = 0.776, 0.827, 0.647, 1.0
   				}
   				Biome
-  				{	
+  				{
     					name = Planitia
-					displayName = Planitia
+					displayName = #LOC_PWDD_Biome_Planitia
     					value = 0.9
     					color = 0.0, 0.0, 0.0, 1.0
   				}
   				Biome
-  				{	
+  				{
     					name = Mount Nedzer
-					displayName = Mount Nedzer
+					displayName = #LOC_PWDD_Biome_MountNedzer
     					value = 1.75
     					color = 1.0, 1.0, 1.0, 1.0
   				}

--- a/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Shana.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Shana.cfg
@@ -12,7 +12,9 @@
         }
         Properties
         {
-            description = Shana is the oldest moon of Glumo, as evident by its cratered surface, equatorial ridge and darker half. The difference in color between Shana's two halves is striking. Its surface has many ledges and cliffs, which have formed from the massive tidal forces exerted on it by Glumo.
+			displayName = #LOC_PWDD_name_Shana
+            description = #LOC_PWDD_Shana_description
+
             radius = 85000
             geeASL = 0.08 // Gravity as sea level, 1 being kerbin gravity, 0 being no gravity.
             tidallyLocked = true // Whether or not the body is tidally locked.
@@ -35,70 +37,70 @@
 				Biome
   				{
     					name = Lowlands
-					displayName = Lowlands
+					displayName = #LOC_PWDD_Biome_Low
     					value = 7
     					color = 0.412, 0.314, 0.816, 1.0
   				}
   				Biome
   				{	
     					name = Midlands
-					displayName = Midlands
+					displayName = #LOC_PWDD_Biome_Mid
     					value = 3
     					color = 0.478, 0.459, 0.827, 1.0
   				}
   				Biome
   				{	
     					name = Highlands
-					displayName = Highlands
+					displayName = #LOC_PWDD_Biome_High
     					value = 1.25
     					color = 0.537, 0.616, 0.816, 1.0
   				}
   				Biome
   				{	
     					name = Mountains
-					displayName = Mountains
+					displayName = #LOC_PWDD_Biome_Mountains
     					value = 1.25
     					color = 0.561, 0.690, 0.812, 1.0
   				}
 				Biome
   				{
     					name = DarkLowlands
-					displayName = Dark Lowlands
+					displayName = #LOC_PWDD_Biome_DarkLow
     					value = 7
     					color = 0.749, 0.247, 0.247, 1.0
   				}
 				Biome
   				{
     					name = DarkMidlands
-					displayName = Dark Midlands
+					displayName = #LOC_PWDD_Biome_DarkMid
     					value = 7
     					color = 0.765, 0.396, 0.396, 1.0
   				}
 				Biome
   				{
     					name = DarkHighlands
-					displayName = Dark Highlands
+					displayName = #LOC_PWDD_Biome_DarkHigh
     					value = 7
     					color = 0.812, 0.529, 0.529, 1.0
   				}
 				Biome
   				{
     					name = DarkMountains
-					displayName = Dark Mountains
+					displayName = #LOC_PWDD_Biome_DarkMountains
     					value = 7
     					color = 0.843, 0.592, 0.592, 1.0
   				}
   				Biome
   				{	
     					name = Poles
-					displayName = Poles
+					displayName = #LOC_PWDD_Biome_Poles
     					value = 0.9
     					color = 0.0, 0.0, 0.0, 1.0
   				}
   				Biome
   				{	
     					name = EquatorialRidge
-					displayName = Equatorial Ridge
+					displayName = #LOC_PWDD_Biome_EquatorialRidge
     					value = 1.75
     					color = 1.0, 1.0, 1.0, 1.0
   				}

--- a/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Umod.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Umod.cfg
@@ -13,11 +13,12 @@
 		}
 		Properties
 		{
-			description = It's believed that Umod has re-formed after colliding with another body. Pieces of it can still be seen in the form of Axod's rings.
+			displayName = #LOC_PWDD_name_Umod
+			description = #LOC_PWDD_Umod_description
 
 			radius = 30000
 			geeASL = 0.01
-			displayName = Umod^N
+
 			rotates = true
 			rotationPeriod = -7400.75216749825
 			biomeMap = PromisedWorlds/_Systems/Debdeb/PluginData/Umod_Biomes.png
@@ -41,42 +42,42 @@
 				Biome
   				{
     					name = Lowlands
-					displayName = Lowlands
+					displayName = #LOC_PWDD_Biome_Low
     					value = 7
     					color = 0.412, 0.314, 0.816, 1.0
   				}
   				Biome
   				{	
     					name = Midlands
-					displayName = Midlands
+					displayName = #LOC_PWDD_Biome_Mid
     					value = 3
     					color = 0.478, 0.459, 0.827, 1.0
   				}
   				Biome
   				{	
     					name = Highlands
-					displayName = Highlands
+					displayName = #LOC_PWDD_Biome_High
     					value = 1.25
     					color = 0.537, 0.616, 0.816, 1.0
   				}
   				Biome
   				{	
     					name = Peaks
-					displayName = Peaks
+					displayName = #LOC_PWDD_Biome_Peaks
     					value = 1.25
     					color = 0.561, 0.690, 0.812, 1.0
   				}
   				Biome
   				{	
     					name = Craters
-					displayName = Craters
+					displayName = #LOC_PWDD_Biome_Craters
     					value = 0.9
     					color = 0.0, 0.0, 0.0, 1.0
   				}
   				Biome
   				{	
     					name = Crater Peaks
-					displayName = Crater Peaks
+					displayName = #LOC_PWDD_Biome_CraterPeaks
     					value = 1.75
     					color = 1.0, 1.0, 1.0, 1.0
   				}

--- a/GameData/PromisedWorlds/_Systems/Debdeb/Misc/Localization/en-us.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Misc/Localization/en-us.cfg
@@ -1,0 +1,155 @@
+
+// Names (to allow full modularity, only Debdeb names should be in this localization file!)
+// Debdeb - PWDD
+// Tuun - PWTU
+// Qeg - PWQE
+
+Localization
+{
+    en-us
+    {
+        // ******** Names ********
+        #LOC_PWDD_name_Axod = Axod^N
+        #LOC_PWDD_name_Bis = Bis^N
+        #LOC_PWDD_name_Charr = Charr^N
+        #LOC_PWDD_name_Debdeb = Debdeb^N
+        #LOC_PWDD_name_Diros = Diros^N
+        #LOC_PWDD_name_Donk = Donk^N
+        #LOC_PWDD_name_Dorau = Dorau^N
+        #LOC_PWDD_name_Glumo = Glumo^N
+        #LOC_PWDD_name_Gup = Gup^N
+        #LOC_PWDD_name_Gurdamma = Gurdama^N
+        #LOC_PWDD_name_Jup = Jup^N
+        #LOC_PWDD_name_Kleid = Kleid^N
+        #LOC_PWDD_name_Lapat = Lapat^N
+        #LOC_PWDD_name_Merbel = Merbel^N
+        #LOC_PWDD_name_Mesma = Mesma^N
+        #LOC_PWDD_name_Noj = Noj^N
+        #LOC_PWDD_name_Omasa = Omasa^N
+        #LOC_PWDD_name_Ovin = Ovin^N
+        #LOC_PWDD_name_Rosh = Rosh^N
+        #LOC_PWDD_name_Shana = Shana^N
+        #LOC_PWDD_name_Umod = Umod^N
+
+        // ******** Descriptions ********
+        #LOC_PWDD_Axod_description = Axod is the bluest object ever observed by kerbalkind, with blue rings, blue clouds and blue skies. What it lacks in size, it makes up for in beautiful views and many unique worlds to explore.
+        #LOC_PWDD_Bis_description = Bis is Dorau's distant icy companion. Its cracked spotty surface resembles a round biscuit, hence the name.
+        #LOC_PWDD_Charr_description = Charr is a beaten world of pure iron that basks in Debdeb's intense heat. It's likely the youngest planet in the system and has formed from material inside Debdeb's planetary debris disk. On its discovery, road signage manufacturers rejoiced as they believed they found a gold mine for glow-in-the-dark paint. They were soon dismayed when someone explained that Charr's distinct glow is due to molten iron on its surface, which has previously been proven subpar for use in road signage.
+        #LOC_PWDD_Debdeb_description = Debdeb is a G-type main sequence star, slightly dimmer and smaller than Kerbol. It is the closest star to Kerbol, serving as a constant reminder that we are still not the center of the universe. It's a young star surrounded by a proto-planetary disk, in which some planets are forming. It should not be looked at directly, as this causes similar harmful effects to when looking at Kerbol, and has been regarded by some doctors as "A dim-witted thing to do".
+        #LOC_PWDD_Diros_description = Diros is the larger body of its binary pair. It has some impressive terrain with mountains and craters across its surface. From here, one can observe the entire Glumo system at once.
+        #LOC_PWDD_Donk_description = It's believed that Donk was formed from a collision between Gurdamma and another nearby planet, hence the ring that it is forming in. It's surface is young, with patches of cooled lava across it's surface. When asked what to name this newly-discovered moon, Nate Kerman recalled a particular high-velocity encounter his head had with the top of the observatory door that evening. And so Donk was the new big space discovery that everybody was talking about.
+        #LOC_PWDD_Dorau_description = Dorau is a cold snowball lurking in the farthest reaches of the Debdeb system. It was called a planet from day one and anybody who thought otherwise was shown the door. Its poofy atmosphere makes it look fuzzy when observed, like a space pompom. Its most unique features are the liquid nitrogen lakes seen dotted across its surface. Kerbal engineers claim that their standard spacesuits are "probably" able to handle a swim there.
+        #LOC_PWDD_Glumo_description = Glumo is the largest planet of the Debdeb system, with a complex ring system and clouds of many colors. Its monstrous size puts Jool to shame. The view of the vast ring system from the moons must be spectacular. It has starred in many prog rock covers since its discovery.
+        #LOC_PWDD_Gup_description = Gup is a little disk of rock with a crazy orbit. It's existence further proves the Gurdamma collision theory as it is likely a piece of ejected material. It was likely flung like a frisbee out into space, hence it's fast rotation and flat shape. It's resemblence to a flying saucer has led to many embarassing reports and several astronomers being driven to insanity. Please wear a jetpack when walking near the equator. The Kerbal Astronomical Society is yet to determine the feasability of using it for games of space-frisbee.
+        #LOC_PWDD_Gurdamma_description = Kerbalkind's first stop on the way to the Debdeb system. Gurdamma offers a glimpse at what Kerbin could have looked like during the Kadeon eon, 4 billion years ago. It has an active, shifting surface, which is pockmarked all over with many craters of all shapes and sizes, hinting at a major cosmic event in the recent past. There are also vast water oceans just like Kerbin, but it's atmosphere is toxic with very little oxygen present. It dons a beautiful ring system where it's largest moon, Donk, is currently forming. Knowing what we do about our own planet, one can only wonder what sort of future this planet has in store.
+        #LOC_PWDD_Jut_description = Jut is the smaller of its binary pair. It is known for its "swiss cheese" appearance and chaotic rotation. KSC does not recommend attempts to eat it.
+        #LOC_PWDD_Kleid_description =
+        #LOC_PWDD_Lapat_description = Don't be turned away by its angry-red oceans. Lapat is a heavenly respite from the chaos of the inner Debdeb system. Despite being mostly icy, Lapat has some habitable features around the equator. How it got its oxygen-rich atmosphere at such a young age is a mystery, making it one of the most anomalous bodies in the Debdeb system.
+        #LOC_PWDD_Merbel_description = Don't be fooled by this place. Merbel may have blue skies, stunning views and an ocean from paradise, but the oceans are full of toxic copper sulphate and there isn't enough oxygen in the air to breathe. It's still very pretty though and the place still has a lot to offer with some refining. Merbel's orbit and size suggests it was once a planet itself. As Glumo moved outwards through the Debdeb system, Merbel was snatched and forced into a wacky orbit. This event may have helped form Glumo's spectacular rings.
+        #LOC_PWDD_Mesma_description = Mesma is Axod's most unusual companion. It's surface is dominated by icy plains with some rocky hills poking through. Some say it resembles a burnt marshmallow... a space marshmallow... yum.
+        #LOC_PWDD_Noj_description = Noj is in an awkward place. Due to its puny size and precarious orbit, it is almost inaccessible. Many compare its appearance to a frisbee, a scone, or a raviolo. This is from the accumulation of material from Glumo's rings. This process has also traced out a gap through the rings.
+        #LOC_PWDD_Omasa_description = Omasa matches Mesma's orbit on the opposite side. An unusual arrangement which earned the two moons names after twin knights from Kerbal mythology. This can be deceiving as up close they are nothing alike at all.
+        #LOC_PWDD_Ovin_description = With a choked atmosphere that eats spacecraft for breakfast, a shattered surface with few places to land and a fierce gravitational pull that threatens to crush the bones of any kerbal who dares to walk on it's surface, Ovin is a horrifying planet and will be a colossal challenge for kerbalkind to conquer. It's monstrous size and density makes us believe that it may be the core of a gas giant that lost it's atmosphere in some cosmic event. It's discovery re-defined how we think about terrestrial planets and undoubtedly gave some kids (and scientists) nightmares for many months.
+        #LOC_PWDD_Rosh_description = Rosh is Axod's largest moon. Its grimy surface is as black as coal, however it is unlikely that there is any coal there. Some compare its many planitiae to the inside of an onion.
+        #LOC_PWDD_Shana_description = Shana is the oldest moon of Glumo, as evident by its cratered surface, equatorial ridge and darker half. The difference in color between Shana's two halves is striking. Its surface has many ledges and cliffs, which have formed from the massive tidal forces exerted on it by Glumo.
+        #LOC_PWDD_Umod_description = It's believed that Umod has re-formed after colliding with another body. Pieces of it can still be seen in the form of Axod's rings.
+
+
+        // ******** Biomes ********
+        // Altitude
+        #LOC_PWDD_Biome_Low = Lowlands
+        #LOC_PWDD_Biome_Mid = Midlands
+        #LOC_PWDD_Biome_High = Highlands
+
+        // Location
+        #LOC_PWDD_Biome_Equator = Equator
+
+        // Polar
+        #LOC_PWDD_Biome_Poles = Poles
+        #LOC_PWDD_Biome_PolarLow = Polar Lowlands
+        #LOC_PWDD_Biome_PolarMid = Polar Midlands
+        #LOC_PWDD_Biome_PolarHigh = Polar Highlands
+        #LOC_PWDD_Biome_PolarMountains = Polar Mountains
+        #LOC_PWDD_Biome_PolarDeepSeas = Polar Deep Seas
+        #LOC_PWDD_Biome_PolarSeas = Polar Seas
+        #LOC_PWDD_Biome_PolarShallowSeas = Polar Shallow Seas
+        #LOC_PWDD_Biome_PolarCoasts = Polar Coasts
+
+        // Dark
+        #LOC_PWDD_Biome_DarkLow = Dark Lowlands
+        #LOC_PWDD_Biome_DarkMid = Dark Midlands
+        #LOC_PWDD_Biome_DarkHigh = Dark Highlands
+        #LOC_PWDD_Biome_DarkMountains = Dark Mountains
+
+        // Geographical features
+        #LOC_PWDD_Biome_Mares = Mares
+        #LOC_PWDD_Biome_Craters = Craters
+        #LOC_PWDD_Biome_CraterPeaks = Crater Peaks
+        #LOC_PWDD_Biome_Canyons = Canyons
+        #LOC_PWDD_Biome_Cracks = Cracks
+        #LOC_PWDD_Biome_Faultlines = Faultlines
+        #LOC_PWDD_Biome_Planitia = Planitia
+
+        // Mountains
+        #LOC_PWDD_Biome_Mountains = Mountains
+        #LOC_PWDD_Biome_Peaks = Peaks
+        #LOC_PWDD_Biome_EquatorialRidge = Equatorial Ridge
+        #LOC_PWDD_Biome_Slopes = Slopes
+        #LOC_PWDD_Biome_Volcanoes = Volcanoes
+        #LOC_PWDD_Biome_MountBogue = Mount Bogue
+        #LOC_PWDD_Biome_MountNedzer = Mount Nedzer
+
+        // Ashen
+        #LOC_PWDD_Biome_AshenLow = Ashen Lowlands
+        #LOC_PWDD_Biome_AshenHigh = Ashen Highlands
+        #LOC_PWDD_Biome_AshenMountains = Ashen Mountains
+        #LOC_PWDD_Biome_AshenFaultlines = Ashen Faultlines
+
+        // Icy
+        #LOC_PWDD_Biome_IcyCliffs = Icy Cliffs
+        #LOC_PWDD_Biome_IcyLow = Icy Lowlands
+        #LOC_PWDD_Biome_IcyHigh = Icy Highlands
+        #LOC_PWDD_Biome_IcyHills = Icy Hills
+        #LOC_PWDD_Biome_IceSheets = Ice LOC_PWDD_Biome_IceSheets
+
+        // Rocky
+        #LOC_PWDD_Biome_RockyFlats = Rocky Flats
+        #LOC_PWDD_Biome_RockySlopes = Rocky Slopes
+        #LOC_PWDD_Biome_RockyMountains = Rocky Mountains
+
+        // Charr
+        #LOC_PWDD_Biome_MoltenCraters = Molten Craters
+        #LOC_PWDD_Biome_HotCraters = Hot Craters
+        #LOC_PWDD_Biome_MetallicMountains = Metallic Mountains
+
+        #LOC_PWDD_Biome_BasaltBasins = Basalt Basins
+        #LOC_PWDD_Biome_LavaLakes = Lava Lakes
+
+        // Seas/Lakes/Rivers
+        #LOC_PWDD_Biome_Shores = Shores
+        #LOC_PWDD_Biome_Coasts = Coasts
+        #LOC_PWDD_Biome_NitrogenSeas = Nitrogen Seas
+        #LOC_PWDD_Biome_DeepOceans = Deep Oceans
+        #LOC_PWDD_Biome_Oceans = Oceans
+        #LOC_PWDD_Biome_DeepSeas = Deep Seas
+        #LOC_PWDD_Biome_Seas = Seas
+        #LOC_PWDD_Biome_ShallowSeas = Shallow Seas
+        #LOC_PWDD_Biome_CraterLakes = Crater Lakes
+        #LOC_PWDD_Biome_FloodedFaultlines = Flooded Faultlines
+        #LOC_PWDD_Biome_ShankastRiver = ShankastRiver
+        #LOC_PWDD_Biome_TealRiver = TealRiver
+        #LOC_PWDD_Biome_MylonRiver = MylonRiver
+
+        // Ovin
+        #LOC_PWDD_Biome_Nedzerfjord = Nedzerfjord
+        #LOC_PWDD_Biome_ValleyOfDespair = Valley of Despair
+        #LOC_PWDD_Biome_GulfOfHairy = Gulf of Hairy
+        #LOC_PWDD_Biome_DustyCrater = Dusty Crater
+        #LOC_PWDD_Biome_HefftyCliffs = HefftyCliffs
+        #LOC_PWDD_Biome_GreatNorthernRift = Great Northern Rift
+        #LOC_PWDD_Biome_GreatSouthernRift = Great Southern Rift
+        #LOC_PWDD_Biome_LesserNorthernRift = Lesser Northern Rift
+        #LOC_PWDD_Biome_VinitaFissure = Vinita Fissure
+
+    }
+}


### PR DESCRIPTION
Adds displayNames to a few planets that do not have them
Moves planets' displayNames and descriptions to a localization file.

The localization file is specific to the Debdeb system, and uses localization strings starting with LOC_PWDD. Localization for other systems within Promised Worlds will need to use different files to ensure that the systems are modular.

No text is changed or rewritten, only moved to a localization file.
Science defs are left alone by this as there is a larger science def reorganization in progress.

I've tested this in game and all strings appear correctly (except for Kleid, which didn't have a description to start with)