### PR TITLE
Restore Charr's hazardous tags for extra danger

### DIFF
--- a/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Charr.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Charr.cfg
@@ -210,7 +210,7 @@
 			Item
 			{
 				ambientTemp = 2000
-				biomeName = Molten Craters
+				biomeName = MoltenCraters
 				AltitudeCurve
 				{
 					key = 493000 1.0 0.00000 -3.3E-4
@@ -225,7 +225,7 @@
 			Item
 			{
 				ambientTemp = 1200
-				biomeName = Hot Craters
+				biomeName = HotCraters
 				AltitudeCurve
 				{
 					key = 493000 1.0 0.00000 -3.3E-4


### PR DESCRIPTION
A typo in the biome names for Charr's HazardousBody tags means that it's not all that hot, even in the Molten Craters.
This fixes that.

Before:
<img width="1916" height="1078" alt="Screenshot_20250827_094110-2" src="https://github.com/user-attachments/assets/358a7c04-aa61-47df-b7aa-5fa303d64d00" />

After:
<img width="1104" height="610" alt="Screenshot_20250827_101102" src="https://github.com/user-attachments/assets/61d06c3a-d95d-462c-a39f-8d11d50d908a" />
